### PR TITLE
Allow links with spaces in the URL part

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var makeEmitter = require('make-object-an-emitter')
 
-var noddityLinkRegex = /\[\[([\/\w.-]+)(?:\|([^\]>\n]+))?\]\]/gm
+var noddityLinkRegex = /\[\[([\/\w. -]+)(?:\|([^\]>\n]+))?\]\]/gm
 
 function numberOfOccurrances(str, input) {
 	var occurrances = 0

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var makeEmitter = require('make-object-an-emitter')
 
-var noddityLinkRegex = /\[\[([\/\w. -]+)(?:\|([^\]>\n]+))?\]\]/gm
+var noddityLinkRegex = /\[\[([\/\w., -]+)(?:\|([^\]>\n]+))?\]\]/gm
 
 function numberOfOccurrances(str, input) {
 	var occurrances = 0

--- a/test.js
+++ b/test.js
@@ -23,6 +23,17 @@ test('replaces a title-less link containing a "/" with an <a> element', function
 	t.end()
 })
 
+test('replaces a title-less link containing a " " with an <a> element', function(t) {
+	var input = "<p>wassup my home [[target page]]</p>"
+
+	var linkify = new Linkify('#/wat/').linkify
+
+	var output = linkify(input)
+
+	t.equal(output, '<p>wassup my home <a href="#/wat/target page">target page</a></p>', 'equal to the string that I said it should be')
+	t.end()
+})
+
 test('turns a link with a title into an <a> element', function(t) {
 	var input = "<p>wassup my home [[target|teh page]]</p>"
 

--- a/test.js
+++ b/test.js
@@ -34,6 +34,17 @@ test('replaces a title-less link containing a " " with an <a> element', function
 	t.end()
 })
 
+test('replaces a title-less link containing a "," with an <a> element', function(t) {
+	var input = "<p>wassup my home [[target,page]]</p>"
+
+	var linkify = new Linkify('#/wat/').linkify
+
+	var output = linkify(input)
+
+	t.equal(output, '<p>wassup my home <a href="#/wat/target,page">target,page</a></p>', 'equal to the string that I said it should be')
+	t.end()
+})
+
 test('turns a link with a title into an <a> element', function(t) {
 	var input = "<p>wassup my home [[target|teh page]]</p>"
 


### PR DESCRIPTION
I think this was the cause of the weird error.

The link `[[a b.md]]` doesn't get matched and replaced by the linkifier as it is now. So the markdown parser comes along, and is like, "hey, that's not a valid footnote reference!", and then the internet breaks.

This fixes the internet. However, I'm not sure if the spaces should be URL encoded. I decided not to URL encode them since they're in the has fragment.