### PR TITLE
Encode characters in links

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var makeEmitter = require('make-object-an-emitter')
 
-var noddityLinkRegex = /\[\[([\/\w.\-\' ]+)(?:\|([^\]>\n]+))?\]\]/gm
+var noddityLinkRegex = /\[\[([^\]\|]+)(?:\|([^\]>\n]+))?\]\]/gm
 
 function numberOfOccurrances(str, input) {
 	var occurrances = 0
@@ -10,6 +10,10 @@ function numberOfOccurrances(str, input) {
 		current = input.indexOf(str, current + 1)
 	}
 	return occurrances
+}
+
+function encodeFolderUsingUri(file) {
+	return file.split('/').map(function (part) { return encodeURIComponent(part) }).join('/')
 }
 
 function pureLinkify(emitter, rootPath, htmlString) {
@@ -22,7 +26,7 @@ function pureLinkify(emitter, rootPath, htmlString) {
 		} else {
 			linkText = linkText || page
 			emitter.emit('link', page)
-			return '<a href="' + rootPath + page + '">' + linkText + '</a>'
+			return '<a href="' + rootPath + encodeFolderUsingUri(page) + '">' + linkText + '</a>'
 		}
 	})
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var makeEmitter = require('make-object-an-emitter')
 
-var noddityLinkRegex = /\[\[([\/\w.-]+)(?:\|([^\]>\n]+))?\]\]/gm
+var noddityLinkRegex = /\[\[([\/\w.\-\' ]+)(?:\|([^\]>\n]+))?\]\]/gm
 
 function numberOfOccurrances(str, input) {
 	var occurrances = 0

--- a/test.js
+++ b/test.js
@@ -30,7 +30,7 @@ test('replaces a title-less link containing a " " with an <a> element', function
 
 	var output = linkify(input)
 
-	t.equal(output, '<p>wassup my home <a href="#/wat/target page">target page</a></p>', 'equal to the string that I said it should be')
+	t.equal(output, '<p>wassup my home <a href="#/wat/target%20page">target page</a></p>', 'equal to the string that I said it should be')
 	t.end()
 })
 
@@ -41,7 +41,7 @@ test('replaces a title-less link containing a "," with an <a> element', function
 
 	var output = linkify(input)
 
-	t.equal(output, '<p>wassup my home <a href="#/wat/target,page">target,page</a></p>', 'equal to the string that I said it should be')
+	t.equal(output, '<p>wassup my home <a href="#/wat/target%2Cpage">target,page</a></p>', 'equal to the string that I said it should be')
 	t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -145,3 +145,15 @@ test("The emitter is also a function", function(t) {
 
 	emitter("<p>wassup my home [[butts|teh page]]</p>")
 })
+
+test("A post name with slashes and stuff", function(t) {
+	var testString = "[[Web/Sermons/New Testament/Revelation/Pickering's Translation/PickeringTranslationRevelation.md|translation]]"
+
+	var linkify = new Linkify('#/wat/')
+
+	var output = linkify(testString)
+
+	t.equal(output, '<a href="#/wat/Web/Sermons/New Testament/Revelation/Pickering\'s Translation/PickeringTranslationRevelation.md">translation</a>')
+
+	t.end()
+})

--- a/test.js
+++ b/test.js
@@ -153,7 +153,32 @@ test("A post name with slashes and stuff", function(t) {
 
 	var output = linkify(testString)
 
-	t.equal(output, '<a href="#/wat/Web/Sermons/New Testament/Revelation/Pickering\'s Translation/PickeringTranslationRevelation.md">translation</a>')
+	t.equal(output, '<a href="#/wat/Web/Sermons/New%20Testament/Revelation/Pickering\'s%20Translation/PickeringTranslationRevelation.md">translation</a>')
+
+	t.end()
+})
+
+test("Encoding ampersands and whatnot", function(t) {
+	var testString = "[[thing&junk.yarp|BLARP]]"
+
+	var linkify = new Linkify('#/wat/')
+
+	var output = linkify(testString)
+
+	t.equal(output, '<a href="#/wat/thing%26junk.yarp">BLARP</a>')
+
+	t.end()
+
+})
+
+test("A PK link", function(t) {
+	var testString = "[[Web/Sermons/New Testament/Revelation/Pickering's Translation/PickeringTranslationRevelation.md|translation]]"
+
+	var linkify = new Linkify('#/wat/')
+
+	var output = linkify(testString)
+
+	t.equal(output, '<a href="#/wat/Web/Sermons/New%20Testament/Revelation/Pickering\'s%20Translation/PickeringTranslationRevelation.md">translation</a>')
 
 	t.end()
 })


### PR DESCRIPTION
I think this is the direction Noddity needs to go, but it's a breaking change that will require changes to at least the webapp at the same time.

Right now the webapp expects unencoded characters after the hash, and encodes the url before sending it to the server.